### PR TITLE
feat: add regexMatch template function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/KyleBanks/goodreads v0.0.0-20200527082926-28539417959b
 	github.com/caarlos0/env/v6 v6.10.1
+	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/dustin/go-humanize v1.0.1
 	github.com/mmcdole/gofeed v1.2.1
 	github.com/shurcooL/githubv4 v0.0.0-20191127044304-8f68eb5628d0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 		/* Utils */
 		"humanize": humanized,
 		"reverse":  reverse,
+		"regexMatch": regexMatch,
 		"now":      time.Now,
 		"contains": strings.Contains,
 		"toLower":  strings.ToLower,

--- a/template.go
+++ b/template.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/dlclark/regexp2"
 	"github.com/dustin/go-humanize"
 )
 
@@ -32,4 +33,11 @@ func reverse(s interface{}) interface{} {
 	}
 
 	return s
+}
+
+// regexMatch returns true or false if the string matches
+// the given regular expression
+func regexMatch(re, s string) (bool, error) {
+	compiled := regexp2.MustCompile(re, 0)
+	return compiled.MatchString(s)
 }


### PR DESCRIPTION
Adds the `regexMatch` function, using [`regexp2`](https://github.com/dlclark/regexp2) to support negative lookaheads to exclude some organizations.